### PR TITLE
HPCC4J-477 Ensure DZ paths contain trailing slash > 7.12.98

### DIFF
--- a/wsclient/src/main/java/org/hpccsystems/ws/client/HPCCFileSprayClient.java
+++ b/wsclient/src/main/java/org/hpccsystems/ws/client/HPCCFileSprayClient.java
@@ -26,7 +26,6 @@ import java.util.List;
 import java.util.Properties;
 
 import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.xpath.XPath;
 import javax.xml.xpath.XPathExpression;
@@ -68,6 +67,7 @@ import org.hpccsystems.ws.client.gen.axis2.filespray.latest.SprayFixed;
 import org.hpccsystems.ws.client.gen.axis2.filespray.latest.SprayFixedResponse;
 import org.hpccsystems.ws.client.gen.axis2.filespray.latest.SprayResponse;
 import org.hpccsystems.ws.client.gen.axis2.filespray.latest.SprayVariable;
+import org.hpccsystems.ws.client.platform.Version;
 import org.hpccsystems.ws.client.utils.Connection;
 import org.hpccsystems.ws.client.utils.DelimitedDataOptions;
 import org.hpccsystems.ws.client.utils.EqualsUtil;
@@ -109,6 +109,8 @@ public class HPCCFileSprayClient extends BaseHPCCWsClient
     private static String                     WSDLURL                = null;
 
     private static final PhysicalFileStruct[] NO_FILES               = {};
+    public static final Version               TrailingSlashPathHPCCVer = new Version(7, 12, 98); //First known HPCC version in which DZ paths are
+                                                                                                 //expected to contain trailing slash
 
     /**
      * Load WSDLURL.
@@ -346,6 +348,9 @@ public class HPCCFileSprayClient extends BaseHPCCWsClient
     {
         try
         {
+            HPCCWsSMCClient wssmc = HPCCWsSMCClient.get(connection);
+            targetHPCCBuildVersion = new Version(wssmc.getHPCCBuild());
+
             setActiveConnectionInfo(connection);
             stub = setStubOptions(new FileSprayStub(connection.getBaseUrl() + FILESPRAYWSDLURI), connection);
         }
@@ -598,7 +603,14 @@ public class HPCCFileSprayClient extends BaseHPCCWsClient
             DropZone[] dropZone = resp.getDropZones().getDropZone();
             for (int i = 0; i < dropZone.length; i++)
             {
-                dropZonesWrapper.add(new DropZoneWrapper(dropZone[i]));
+                DropZoneWrapper currentDZ = new DropZoneWrapper(dropZone[i]);
+
+                if(compatibilityCheck(TrailingSlashPathHPCCVer))
+                {
+                    currentDZ.setPath(Utils.ensureTrailingPathSlash(currentDZ.getPath(), currentDZ.getLinux()));
+                }
+
+                dropZonesWrapper.add(currentDZ);
             }
         }
 

--- a/wsclient/src/main/java/org/hpccsystems/ws/client/utils/Utils.java
+++ b/wsclient/src/main/java/org/hpccsystems/ws/client/utils/Utils.java
@@ -47,9 +47,9 @@ public class Utils
 {
     private final static Logger log            = LogManager.getLogger(Utils.class);
 
-    final static char           LINUX_SEP      = '/';
-    final static char           WIN_SEP        = '\\';
-    final static String         ISO8601_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.sss'Z'";
+    public final static char           LINUX_SEP      = '/';
+    public final static char           WIN_SEP        = '\\';
+    public final static String         ISO8601_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.sss'Z'";
 
     public enum LogLevel
     {
@@ -1059,5 +1059,23 @@ public class Utils
             throw new XPathExpressionException ("Could not create new safe XML doc builder");
 
         return safeXMLDocBuilder;
+    }
+
+    public static String ensureTrailingPathSlash(String path)
+    {
+        return ensureTrailingPathSlash(path, (path.contains(Character.toString(LINUX_SEP)) || path.length() == 0) ? LINUX_SEP : WIN_SEP);
+    }
+
+    public static String ensureTrailingPathSlash(String path, String useLinuxSep)
+    {
+        return ensureTrailingPathSlash(path, useLinuxSep.equalsIgnoreCase("true") ? LINUX_SEP : WIN_SEP);
+    }
+
+    public static String ensureTrailingPathSlash(String path, char slash)
+    {
+        if (path.length() == 0 || path.charAt(path.length()-1) != slash)
+            path = path + slash;
+
+        return path;
     }
 }

--- a/wsclient/src/test/java/org/hpccsystems/ws/client/FileSprayClientTest.java
+++ b/wsclient/src/test/java/org/hpccsystems/ws/client/FileSprayClientTest.java
@@ -15,6 +15,7 @@ import java.util.List;
 import org.apache.axis2.AxisFault;
 import org.hpccsystems.ws.client.platform.test.BaseRemoteTest;
 import org.hpccsystems.ws.client.utils.Connection;
+import org.hpccsystems.ws.client.utils.Utils;
 import org.hpccsystems.ws.client.wrappers.ArrayOfBaseExceptionWrapper;
 import org.hpccsystems.ws.client.wrappers.ArrayOfEspExceptionWrapper;
 import org.hpccsystems.ws.client.wrappers.gen.filespray.DFUWorkunitsActionResponseWrapper;
@@ -22,6 +23,7 @@ import org.hpccsystems.ws.client.wrappers.gen.filespray.DropZoneFilesResponseWra
 import org.hpccsystems.ws.client.wrappers.gen.filespray.DropZoneWrapper;
 import org.hpccsystems.ws.client.wrappers.gen.filespray.ProgressResponseWrapper;
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
@@ -386,6 +388,31 @@ public class FileSprayClientTest extends BaseRemoteTest
         catch (Exception e)
         {
             Assert.fail(e.getLocalizedMessage());
+        }
+    }
+
+    @Test
+    public void ensuredTrailingSlashDZSince7_12_98()
+    {
+        try
+        {
+            Assume.assumeTrue(filesprayclient.compatibilityCheck(HPCCFileSprayClient.TrailingSlashPathHPCCVer));
+
+            List<DropZoneWrapper> dzs = filesprayclient.fetchDropZones("");
+            Assume.assumeNotNull(dzs);
+            Assume.assumeTrue(dzs.size() > 0);
+
+            for (int i = 0; i < dzs.size(); i++)
+            {
+                DropZoneWrapper thisdz = dzs.get(i);
+                String thisDZsPath = thisdz.getPath();
+                Assert.assertTrue(thisDZsPath.charAt(thisDZsPath.length()-1) == Utils.LINUX_SEP || thisDZsPath.charAt(thisDZsPath.length()-1) == Utils.WIN_SEP);
+            }
+        }
+        catch (Exception e)
+        {
+            e.printStackTrace();
+            Assert.fail();
         }
     }
 }

--- a/wsclient/src/test/java/org/hpccsystems/ws/client/utils/UtilsTest.java
+++ b/wsclient/src/test/java/org/hpccsystems/ws/client/utils/UtilsTest.java
@@ -1,0 +1,66 @@
+package org.hpccsystems.ws.client.utils;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+import com.ibm.icu.impl.Assert;
+
+public class UtilsTest
+{
+    @Test
+    public void testEnsureTrailingSlashNoSlashSpecified()
+    {
+        assertEquals(Utils.ensureTrailingPathSlash(""), Character.toString(Utils.LINUX_SEP)); //no sep in path, default to lin sep
+        assertEquals(Utils.ensureTrailingPathSlash(Character.toString(Utils.LINUX_SEP)), Character.toString(Utils.LINUX_SEP));//no change expected
+        assertEquals(Utils.ensureTrailingPathSlash(Character.toString(Utils.WIN_SEP)), Character.toString(Utils.WIN_SEP)); //no change expected
+        assertEquals(Utils.ensureTrailingPathSlash(Character.toString(Utils.WIN_SEP)+Character.toString(Utils.LINUX_SEP)), Character.toString(Utils.WIN_SEP)+Character.toString(Utils.LINUX_SEP));//no change expected
+        assertEquals(Utils.ensureTrailingPathSlash("C:\\some\\Path"), "C:\\some\\Path\\");
+        assertEquals(Utils.ensureTrailingPathSlash("C:\\some\\Path\\"), "C:\\some\\Path\\");
+        assertEquals(Utils.ensureTrailingPathSlash("/another/path"), "/another/path/");
+        assertEquals(Utils.ensureTrailingPathSlash("/another/path/"), "/another/path/");
+    }
+
+    @Test
+    public void testEnsureTrailingSlashSlashSpecified()
+    {
+        assertEquals(Utils.ensureTrailingPathSlash("", Utils.LINUX_SEP), Character.toString(Utils.LINUX_SEP));
+        assertEquals(Utils.ensureTrailingPathSlash("", Utils.WIN_SEP), Character.toString(Utils.WIN_SEP));
+        assertEquals(Utils.ensureTrailingPathSlash(Character.toString(Utils.LINUX_SEP), Utils.WIN_SEP), Character.toString(Utils.LINUX_SEP)+Utils.WIN_SEP);
+        assertEquals(Utils.ensureTrailingPathSlash(Character.toString(Utils.LINUX_SEP), Utils.LINUX_SEP), Character.toString(Utils.LINUX_SEP));
+        assertEquals(Utils.ensureTrailingPathSlash(Character.toString(Utils.WIN_SEP), Utils.WIN_SEP), Character.toString(Utils.WIN_SEP));
+        assertEquals(Utils.ensureTrailingPathSlash(Character.toString(Utils.WIN_SEP), Utils.LINUX_SEP), Character.toString(Utils.WIN_SEP)+Character.toString(Utils.LINUX_SEP));
+        assertEquals(Utils.ensureTrailingPathSlash(Character.toString(Utils.WIN_SEP)+Character.toString(Utils.LINUX_SEP), Utils.LINUX_SEP), Character.toString(Utils.WIN_SEP)+Character.toString(Utils.LINUX_SEP));
+        assertEquals(Utils.ensureTrailingPathSlash(Character.toString(Utils.WIN_SEP)+Character.toString(Utils.LINUX_SEP), Utils.WIN_SEP), Character.toString(Utils.WIN_SEP)+Character.toString(Utils.LINUX_SEP)+Character.toString(Utils.WIN_SEP));
+        assertEquals(Utils.ensureTrailingPathSlash("C:\\some\\Path", Utils.LINUX_SEP), "C:\\some\\Path\\"+Utils.LINUX_SEP);
+        assertEquals(Utils.ensureTrailingPathSlash("C:\\some\\Path", Utils.WIN_SEP), "C:\\some\\Path\\"+Utils.WIN_SEP);
+        assertEquals(Utils.ensureTrailingPathSlash("C:\\some\\Path\\", Utils.LINUX_SEP), "C:\\some\\Path\\" + Utils.LINUX_SEP);
+        assertEquals(Utils.ensureTrailingPathSlash("C:\\some\\Path\\", Utils.WIN_SEP), "C:\\some\\Path\\");
+        assertEquals(Utils.ensureTrailingPathSlash("/another/path", Utils.LINUX_SEP), "/another/path" + Utils.LINUX_SEP);
+        assertEquals(Utils.ensureTrailingPathSlash("/another/path", Utils.WIN_SEP), "/another/path/"+ Utils.WIN_SEP);
+        assertEquals(Utils.ensureTrailingPathSlash("/another/path/", Utils.LINUX_SEP), "/another/path/");
+        assertEquals(Utils.ensureTrailingPathSlash("/another/path/", Utils.WIN_SEP), "/another/path/"+Utils.WIN_SEP);
+    }
+
+    @Test
+    public void testEnsureTrailingSlashUseLinuxBoolTest()
+    {
+        assertEquals(Utils.ensureTrailingPathSlash("", "true"), Character.toString(Utils.LINUX_SEP));
+        assertEquals(Utils.ensureTrailingPathSlash("", "false"), Character.toString(Utils.WIN_SEP));
+        assertEquals(Utils.ensureTrailingPathSlash("", "xyz"), Character.toString(Utils.WIN_SEP));
+        assertEquals(Utils.ensureTrailingPathSlash(Character.toString(Utils.LINUX_SEP), "false"), Character.toString(Utils.LINUX_SEP)+Utils.WIN_SEP);
+        assertEquals(Utils.ensureTrailingPathSlash(Character.toString(Utils.LINUX_SEP), "true"), Character.toString(Utils.LINUX_SEP));
+        assertEquals(Utils.ensureTrailingPathSlash(Character.toString(Utils.WIN_SEP), "false"), Character.toString(Utils.WIN_SEP));
+        assertEquals(Utils.ensureTrailingPathSlash(Character.toString(Utils.WIN_SEP), "true"), Character.toString(Utils.WIN_SEP)+Character.toString(Utils.LINUX_SEP));
+        assertEquals(Utils.ensureTrailingPathSlash(Character.toString(Utils.WIN_SEP)+Character.toString(Utils.LINUX_SEP), "true"), Character.toString(Utils.WIN_SEP)+Character.toString(Utils.LINUX_SEP));
+        assertEquals(Utils.ensureTrailingPathSlash(Character.toString(Utils.WIN_SEP)+Character.toString(Utils.LINUX_SEP), "false"), Character.toString(Utils.WIN_SEP)+Character.toString(Utils.LINUX_SEP)+Character.toString(Utils.WIN_SEP));
+        assertEquals(Utils.ensureTrailingPathSlash("C:\\some\\Path", "true"), "C:\\some\\Path\\"+Utils.LINUX_SEP);
+        assertEquals(Utils.ensureTrailingPathSlash("C:\\some\\Path", "false"), "C:\\some\\Path\\"+Utils.WIN_SEP);
+        assertEquals(Utils.ensureTrailingPathSlash("C:\\some\\Path\\", "true"), "C:\\some\\Path\\" + Utils.LINUX_SEP);
+        assertEquals(Utils.ensureTrailingPathSlash("C:\\some\\Path\\", "false"), "C:\\some\\Path\\");
+        assertEquals(Utils.ensureTrailingPathSlash("/another/path", "TRUE"), "/another/path" + Utils.LINUX_SEP);
+        assertEquals(Utils.ensureTrailingPathSlash("/another/path", "FALSE"), "/another/path/"+ Utils.WIN_SEP);
+        assertEquals(Utils.ensureTrailingPathSlash("/another/path/", "TrUe"), "/another/path/");
+        assertEquals(Utils.ensureTrailingPathSlash("/another/path/", "FalSe"), "/another/path/"+Utils.WIN_SEP);
+    }
+}


### PR DESCRIPTION
- Provide utilities to ensure trailing slash on a given path string
- Provide junit for ensure trailing slash utility
- Ensure all DZ paths acquired from hpcc >= 7.12.98 contain trailing slash
- Provide DZ path junit

Signed-off-by: Rodrigo Pastrana <rodrigo.pastrana@lexisnexisrisk.com>

<!-- Thank you for submitting a pull request to the hpcc4j project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues (https://track.hpccsystems.com/).
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 hpcc4j-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,and
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and check-off all the items that apply (after pull request has been created)
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [x] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).

## Checklist:
- [x] I have created a corresponding JIRA ticket for this submission
- [x] My code follows the code style of this project.
  - [ ] I have applied the Eclipse code-format template provided.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the HPCC Systems CONTRIBUTORS document (https://github.com/hpcc-systems/HPCC-Platform/wiki/Guide-for-contributors).
- [x] The change has been fully tested:
  - [ ] This change does not cause any existing JUnits to fail.
  - [ ] I have include JUnit coverage to test this change
  - [ ] I have performed system test and covered possible regressions and side effects.
- [ ] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] This change fixes the problem, not just the symptom

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
