### PR TITLE
JAPI-498 DFSClient: Reading long varstrings corrupted

### DIFF
--- a/dfsclient/src/main/java/org/hpccsystems/dfs/client/BinaryRecordReader.java
+++ b/dfsclient/src/main/java/org/hpccsystems/dfs/client/BinaryRecordReader.java
@@ -936,7 +936,7 @@ public class BinaryRecordReader implements IRecordReader
                     throw new IOException("Error, unexpected EOS while constructing UTF16 string.");
                 }
 
-                readSize = (readSize / 2) * 2;
+                readSize = ((readSize + 1) / 2) * 2;
                 if (readSize > OPTIMIZED_STRING_READ_AHEAD)
                 {
                     readSize = OPTIMIZED_STRING_READ_AHEAD;
@@ -947,7 +947,7 @@ public class BinaryRecordReader implements IRecordReader
 
                 for (int j = 0; j < readSize-1; j += 2)
                 {
-                    if (scratchBuffer[j] == '\0' && scratchBuffer[j + 1] == '\0')
+                    if (scratchBuffer[strByteLen + j] == '\0' && scratchBuffer[strByteLen + j + 1] == '\0')
                     {
                         eosLocation = j;
                         break;
@@ -995,7 +995,7 @@ public class BinaryRecordReader implements IRecordReader
 
                 for (int j = 0; j < readSize; j++)
                 {
-                    if (scratchBuffer[j] == '\0')
+                    if (scratchBuffer[strByteLen + j] == '\0')
                     {
                         eosLocation = j;
                         break;

--- a/dfsclient/src/test/java/org/hpccsystems/dfs/client/DFSReadWriteTest.java
+++ b/dfsclient/src/test/java/org/hpccsystems/dfs/client/DFSReadWriteTest.java
@@ -275,7 +275,6 @@ public class DFSReadWriteTest extends BaseRemoteTest
         assertNull("Meta should be null for nonexistent file",meta);
     }
 
-
     private static final String       ALPHABET = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ-_";
     private static final SecureRandom RANDOM   = new SecureRandom();
 
@@ -332,6 +331,45 @@ public class DFSReadWriteTest extends BaseRemoteTest
             {
                 Assert.fail("Record mismatch");
             }
+        }
+    }
+
+    @Test
+    public void longStringTest() throws Exception
+    {
+        // Create a large record dataset
+        FieldDef[] fieldDefs = new FieldDef[4];
+        fieldDefs[0] = new FieldDef("LongVarUnicode", FieldType.VAR_STRING, "", 4, false, false, HpccSrcType.UTF16LE, new FieldDef[0]);
+        fieldDefs[1] = new FieldDef("LongUnicode", FieldType.STRING, "", 64, true, false, HpccSrcType.UTF16LE, new FieldDef[0]);
+        fieldDefs[2] = new FieldDef("LongVarString", FieldType.VAR_STRING, "", 4, false, false, HpccSrcType.SINGLE_BYTE_CHAR, new FieldDef[0]);
+        fieldDefs[3] = new FieldDef("LongString", FieldType.STRING, "", 64, true, false, HpccSrcType.SINGLE_BYTE_CHAR, new FieldDef[0]);
+        FieldDef recordDef = new FieldDef("RootRecord", FieldType.RECORD, "rec", 4, false, false, HpccSrcType.LITTLE_ENDIAN, fieldDefs);
+
+        List<HPCCRecord> records = new ArrayList<HPCCRecord>();
+        for (int i = 0; i < 10; i++)
+        {
+            Object[] fields = new Object[4];
+            fields[0] = generateRandomString(1024);
+            fields[1] = generateRandomString(64);
+            fields[2] = generateRandomString(1024);
+            fields[3] = generateRandomString(64);
+            HPCCRecord record = new HPCCRecord(fields, recordDef);
+            records.add(record);
+        }
+        writeFile(records, "benchmark::long_string::10rows", recordDef,connTO);
+
+        HPCCFile file = new HPCCFile("benchmark::long_string::10rows", connString , hpccUser, hpccPass);
+        List<HPCCRecord> readRecords = readFile(file, connTO, false);
+        if (readRecords.size() < 10)
+        {
+            Assert.fail("Failed to read long string record dataset");
+        }
+
+        for (int i = 0; i < 10; i++)
+        {
+            HPCCRecord record = records.get(i);
+            HPCCRecord readRecord = records.get(i);
+            Assert.assertEquals(record, readRecord);
         }
     }
 

--- a/dfsclient/src/test/java/org/hpccsystems/dfs/client/DFSReadWriteTest.java
+++ b/dfsclient/src/test/java/org/hpccsystems/dfs/client/DFSReadWriteTest.java
@@ -345,7 +345,7 @@ public class DFSReadWriteTest extends BaseRemoteTest
         fieldDefs[3] = new FieldDef("LongString", FieldType.STRING, "", 64, true, false, HpccSrcType.SINGLE_BYTE_CHAR, new FieldDef[0]);
         FieldDef recordDef = new FieldDef("RootRecord", FieldType.RECORD, "rec", 4, false, false, HpccSrcType.LITTLE_ENDIAN, fieldDefs);
 
-        List<HPCCRecord> records = new ArrayList<HPCCRecord>();
+        List<HPCCRecord> originalRecords = new ArrayList<HPCCRecord>();
         for (int i = 0; i < 10; i++)
         {
             Object[] fields = new Object[4];
@@ -354,22 +354,24 @@ public class DFSReadWriteTest extends BaseRemoteTest
             fields[2] = generateRandomString(1024);
             fields[3] = generateRandomString(64);
             HPCCRecord record = new HPCCRecord(fields, recordDef);
-            records.add(record);
+            originalRecords.add(record);
         }
-        writeFile(records, "benchmark::long_string::10rows", recordDef,connTO);
 
-        HPCCFile file = new HPCCFile("benchmark::long_string::10rows", connString , hpccUser, hpccPass);
+        String datasetName = "benchmark::long_string::10rows"; 
+        writeFile(originalRecords, datasetName, recordDef,connTO);
+
+        HPCCFile file = new HPCCFile(datasetName, connString , hpccUser, hpccPass);
         List<HPCCRecord> readRecords = readFile(file, connTO, false);
         if (readRecords.size() < 10)
         {
-            Assert.fail("Failed to read long string record dataset");
+            Assert.fail("Failed to read " + datasetName + " dataset");
         }
 
         for (int i = 0; i < 10; i++)
         {
-            HPCCRecord record = records.get(i);
-            HPCCRecord readRecord = records.get(i);
-            Assert.assertEquals(record, readRecord);
+            HPCCRecord originalRecord = originalRecords.get(i);
+            HPCCRecord readRecord = originalRecords.get(i);
+            Assert.assertEquals(originalRecord, readRecord);
         }
     }
 


### PR DESCRIPTION
- Modified BinaryRecordReader to correctly handle read ahead in varstr
- Added a long string test

Signed-off-by: James McMullan James.McMullan@lexisnexis.com

<!-- Thank you for submitting a pull request to the hpcc4j project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues (https://track.hpccsystems.com/).
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 hpcc4j-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,and
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and check-off all the items that apply (after pull request has been created)
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).

## Checklist:
- [X] I have created a corresponding JIRA ticket for this submission
- [X] My code follows the code style of this project.
  - [ ] I have applied the Eclipse code-format template provided.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [X] I have read the HPCC Systems CONTRIBUTORS document (https://github.com/hpcc-systems/HPCC-Platform/wiki/Guide-for-contributors).
- [ ] The change has been fully tested:
  - [ ] This change does not cause any existing JUnits to fail.
  - [ ] I have include JUnit coverage to test this change
  - [ ] I have performed system test and covered possible regressions and side effects.
- [X] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] This change fixes the problem, not just the symptom

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
