### PR TITLE
HPCC4J-545 Resume read test causes OOM error

### DIFF
--- a/dfsclient/src/test/java/org/hpccsystems/dfs/client/DFSReadWriteTest.java
+++ b/dfsclient/src/test/java/org/hpccsystems/dfs/client/DFSReadWriteTest.java
@@ -178,6 +178,7 @@ public class DFSReadWriteTest extends BaseRemoteTest
                 System.out.println("Messages from file part (" + i + ") read operation:\n" + fileReader.getRemoteReadMessages());
         }
 
+        Runtime runtime = Runtime.getRuntime();
         ArrayList<HPCCRecord> resumedRecords = new ArrayList<HPCCRecord>();
         for (int i = 0; i < resumeInfo.size(); i++)
         {
@@ -193,6 +194,13 @@ public class DFSReadWriteTest extends BaseRemoteTest
                 }
 
                 resumedRecords.add(record);
+            }
+
+            // Periodically run garbage collector to prevent buffers in remote file readers from exhausting free memory
+            // This is only needed due to rapidly creating / destroying thousands of HpccRemoteFileReaders
+            if ((i % 10) == 0)
+            {
+                runtime.gc();
             }
         }
 


### PR DESCRIPTION
- Updated resume read test to periodically run gc

Signed-off-by: James McMullan James.McMullan@lexisnexis.com

<!-- Thank you for submitting a pull request to the hpcc4j project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues (https://track.hpccsystems.com/).
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 hpcc4j-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,and
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and check-off all the items that apply (after pull request has been created)
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).

## Checklist:
- [X] I have created a corresponding JIRA ticket for this submission
- [X] My code follows the code style of this project.
  - [ ] I have applied the Eclipse code-format template provided.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the HPCC Systems CONTRIBUTORS document (https://github.com/hpcc-systems/HPCC-Platform/wiki/Guide-for-contributors).
- [X] The change has been fully tested:
  - [ ] This change does not cause any existing JUnits to fail.
  - [ ] I have include JUnit coverage to test this change
  - [ ] I have performed system test and covered possible regressions and side effects.
- [X] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] This change fixes the problem, not just the symptom

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
