### PR TITLE
HPCC4J-588 HpccRemoteFileReader doesn't pass constuctor params

### DIFF
--- a/dfsclient/src/main/java/org/hpccsystems/dfs/client/HpccRemoteFileReader.java
+++ b/dfsclient/src/main/java/org/hpccsystems/dfs/client/HpccRemoteFileReader.java
@@ -21,7 +21,7 @@ import java.io.IOException;
 import java.util.Iterator;
 
 /**
- * Remote file reader the reads the data represented by a @see org.hpccsystems.dfs.client.DataPartition 
+ * Remote file reader the reads the data represented by a @see org.hpccsystems.dfs.client.DataPartition
  * and constructs records via the provided @see org.hpccsystems.dfs.client#IRecordBuilder.
  */
 public class HpccRemoteFileReader<T> implements Iterator<T>
@@ -72,7 +72,7 @@ public class HpccRemoteFileReader<T> implements Iterator<T>
      *            the record defintion for the dataset
      * @param recBuilder
      *            the IRecordBuilder used to construct records
-     * @param connectTimeout 
+     * @param connectTimeout
      *            the connection timeout in seconds, -1 for default
      * @throws Exception
      *             the exception
@@ -105,47 +105,47 @@ public class HpccRemoteFileReader<T> implements Iterator<T>
 
     /**
      * A remote file reader that reads the part identified by the HpccPart object using the record definition provided.
-     * 
+     *
      * @param dp
      *            the part of the file, name and location
      * @param originalRD
      *            the record defintion for the dataset
      * @param recBuilder
      *            the IRecordBuilder used to construct records
-     * @param connectTimeout 
+     * @param connectTimeout
      *            the connection timeout in seconds, -1 for default
-     * @param limit 
+     * @param limit
      *            the maximum number of records to read from the provided data partition, -1 specifies no limit
-     * @param createPrefetchThread 
+     * @param createPrefetchThread
      *            the input stream should create and manage prefetching on its own thread. If false prefetch needs to be called on another thread periodically.
-     * @param readSizeKB 
+     * @param readSizeKB
      *            read request size in KB, -1 specifies use default value
      * @throws Exception
      * 			  general exception
      */
     public HpccRemoteFileReader(DataPartition dp, FieldDef originalRD, IRecordBuilder recBuilder, int connectTimeout, int limit, boolean createPrefetchThread, int readSizeKB) throws Exception
     {
-        this(dp, originalRD, recBuilder, connectTimeout, limit, true, DEFAULT_READ_SIZE_OPTION, null);
+        this(dp, originalRD, recBuilder, connectTimeout, limit, createPrefetchThread, readSizeKB, null);
     }
 
     /**
      * A remote file reader that reads the part identified by the HpccPart object using the record definition provided.
-     * 
+     *
      * @param dp
      *            the part of the file, name and location
      * @param originalRD
      *            the record defintion for the dataset
      * @param recBuilder
      *            the IRecordBuilder used to construct records
-     * @param connectTimeout 
+     * @param connectTimeout
      *            the connection timeout in seconds, -1 for default
-     * @param limit 
+     * @param limit
      *            the maximum number of records to read from the provided data partition, -1 specifies no limit
-     * @param createPrefetchThread 
+     * @param createPrefetchThread
      *            the input stream should create and manage prefetching on its own thread. If false prefetch needs to be called on another thread periodically.
-     * @param readSizeKB 
+     * @param readSizeKB
      *            read request size in KB, -1 specifies use default value
-     * @param resumeInfo 
+     * @param resumeInfo
      *            FileReadeResumeInfo data required to restart a read from a particular point in a file
      * @throws Exception
      * 			  general exception
@@ -204,7 +204,7 @@ public class HpccRemoteFileReader<T> implements Iterator<T>
 
     /**
      * Returns the stream position within the file.
-     * 
+     *
      * @return stream position
      */
     public long getStreamPosition()
@@ -214,7 +214,7 @@ public class HpccRemoteFileReader<T> implements Iterator<T>
 
     /**
      * Returns read resume info for the current position within the file.
-     * 
+     *
      * @return FileReadResumeInfo
      */
     public FileReadResumeInfo getFileReadResumeInfo()
@@ -224,7 +224,7 @@ public class HpccRemoteFileReader<T> implements Iterator<T>
 
     /**
      * Returns read resume info for the specified position within the file.
-     * 
+     *
      * @param streamPosition the stream position to resume from
      * @return FileReadResumeInfo
      */
@@ -242,7 +242,7 @@ public class HpccRemoteFileReader<T> implements Iterator<T>
 
     /**
      * Returns the number of messages created during the reading process
-     * 
+     *
      * @return number of messages created
      */
     public int getRemoteReadMessageCount()
@@ -256,7 +256,7 @@ public class HpccRemoteFileReader<T> implements Iterator<T>
 
     /**
      * Returns messages created during the file reading process
-     * 
+     *
      * @return Messages concatenated into a String
      */
     public String getRemoteReadMessages()
@@ -284,7 +284,7 @@ public class HpccRemoteFileReader<T> implements Iterator<T>
 
     /**
      * Is there more data
-     * 
+     *
      * @return true if there is a next record
      */
     @Override
@@ -352,7 +352,7 @@ public class HpccRemoteFileReader<T> implements Iterator<T>
 
     /**
      * Returns the RowServiceInputStream used to read the file from dafilesrv
-     * 
+     *
      * @return the input stream
      */
     public RowServiceInputStream getInputStream()
@@ -362,7 +362,7 @@ public class HpccRemoteFileReader<T> implements Iterator<T>
 
     /**
      * Returns the BinaryRecordReader used to construct records
-     * 
+     *
      * @return the record reader
      */
     public BinaryRecordReader getRecordReader()


### PR DESCRIPTION
- Fixed issue where some constructor params were not being passed from overloaded constructors

Signed-off-by: James McMullan James.McMullan@lexisnexis.com

<!-- Thank you for submitting a pull request to the hpcc4j project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues (https://track.hpccsystems.com/).
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 hpcc4j-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,and
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and check-off all the items that apply (after pull request has been created)
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).

## Checklist:
- [X] I have created a corresponding JIRA ticket for this submission
- [X] My code follows the code style of this project.
  - [ ] I have applied the Eclipse code-format template provided.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [X] I have read the HPCC Systems CONTRIBUTORS document (https://github.com/hpcc-systems/HPCC-Platform/wiki/Guide-for-contributors).
- [X] The change has been fully tested:
  - [ ] This change does not cause any existing JUnits to fail.
  - [ ] I have include JUnit coverage to test this change
  - [ ] I have performed system test and covered possible regressions and side effects.
- [X] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] This change fixes the problem, not just the symptom

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
