### PR TITLE
HPCC4J-642 DFSClient FileUtilityTest failing due to credential prompting

### DIFF
--- a/dfsclient/src/main/java/org/hpccsystems/dfs/client/FileUtility.java
+++ b/dfsclient/src/main/java/org/hpccsystems/dfs/client/FileUtility.java
@@ -327,9 +327,11 @@ public class FileUtility
     {
         Console console = System.console();
 
+        boolean nonInteractive = cmd.hasOption("non_interactive");
+
         String user = cmd.getOptionValue("user");
         boolean userIsEmpty = user == null || user.isEmpty();
-        if (userIsEmpty)
+        if (userIsEmpty && !nonInteractive)
         {
             user = new String(console.readLine("Enter username: "));
             userIsEmpty = user == null || user.isEmpty();
@@ -337,7 +339,7 @@ public class FileUtility
 
         String pass = cmd.getOptionValue("pass");
         boolean passIsEmpty = pass == null || pass.isEmpty();
-        if (!userIsEmpty && passIsEmpty)
+        if (!userIsEmpty && passIsEmpty & !nonInteractive)
         {
             pass = new String(console.readPassword("Enter password for " + user + ": "));
         }
@@ -551,6 +553,7 @@ public class FileUtility
         options.addOption("format", true, "Specifies the output format to be used when writing files to disk. Defaults to Thor files.");
         options.addOption("num_threads", true, "Specifies the number of parallel to use to perform operations.");
         options.addOption("out", true, "Specifies the directory that the files should be written to.");
+        options.addOption("non_interactive", false, "Disables prompting for credentials if they are not provided.");
 
         options.addOption(Option.builder("read")
                                 .argName("files")
@@ -571,6 +574,7 @@ public class FileUtility
         options.addOption("pass", true, "Specifies the password used to connect. Defaults to null.");
         options.addOption("num_threads", true, "Specifies the number of parallel to use to perform operations.");
         options.addOption("access_expiry_seconds", true, "Access token expiration seconds.");
+        options.addOption("non_interactive", false, "Disables prompting for credentials if they are not provided.");
 
         options.addOption(Option.builder("file_parts")
                                 .argName("_file_parts")
@@ -590,6 +594,7 @@ public class FileUtility
         options.addRequiredOption("dest_cluster", "Destination Cluster Name", true, "Specifies the name of the cluster to write files back to.");
         options.addOption("dest_url", "Destination Cluster URL", true, "Specifies the URL of the ESP to write to.");
         options.addOption("num_threads", true, "Specifies the number of parallel to use to perform operations.");
+        options.addOption("non_interactive", false, "Disables prompting for credentials if they are not provided.");
 
         options.addOption(Option.builder("copy")
                                 .argName("files")
@@ -611,6 +616,7 @@ public class FileUtility
         options.addOption("dest_url", "Destination Cluster URL", true, "Specifies the URL of the ESP to write to.");
         options.addRequiredOption("dest_cluster", "Destination Cluster Name", true, "Specifies the name of the cluster to write files back to.");
         options.addOption("num_threads", true, "Specifies the number of parallel to use to perform operations.");
+        options.addOption("non_interactive", false, "Disables prompting for credentials if they are not provided.");
 
         options.addOption(Option.builder("write")
                                 .argName("files")
@@ -1738,14 +1744,14 @@ public class FileUtility
             {
                 String readArgs[] = {"-read", srcFile, "-url", srcURL,
                                 "-format", "thor", "-user", user, "-pass", pass,
-                                "-out", "tmp-read"};
+                                "-out", "tmp-read", "-non_interactive"};
 
                 performRead(readArgs, context);
 
                 String writeArgs[] = {"-write", "tmp-read" + File.separator +  srcFile.replace(':', '_') + "*" +  " " + destFile,
                                 "-url", srcURL, "-dest_url", destURL,
                                 "-dest_cluster", destClusterName,
-                                "-user", user, "-pass", pass };
+                                "-user", user, "-pass", pass, "-non_interactive"};
 
                 performWrite(writeArgs, context);
             }

--- a/dfsclient/src/test/java/org/hpccsystems/dfs/client/FileUtilityTest.java
+++ b/dfsclient/src/test/java/org/hpccsystems/dfs/client/FileUtilityTest.java
@@ -46,7 +46,7 @@ public class FileUtilityTest extends BaseRemoteTest
     {
         {
             String readArgs[] = {"-read", "benchmark::integer::20kb", "-url", this.connString,
-                                "-format", "thor", "-user", this.hpccUser, "-pass", this.hpccPass };
+                                "-format", "thor", "-user", this.hpccUser, "-pass", this.hpccPass, "-non_interactive" };
 
             JSONArray results = FileUtility.run(readArgs);
             JSONObject result = results.optJSONObject(0);
@@ -58,7 +58,7 @@ public class FileUtilityTest extends BaseRemoteTest
 
         {
             String readArgs[] = {"-read_test", "benchmark::integer::20kb", "-url", this.connString,
-                                 "-user", this.hpccUser, "-pass", this.hpccPass, "-file_parts", "1" };
+                                 "-user", this.hpccUser, "-pass", this.hpccPass, "-file_parts", "1", "-non_interactive" };
 
             JSONArray results = FileUtility.run(readArgs);
             JSONObject result = results.optJSONObject(0);
@@ -72,7 +72,7 @@ public class FileUtilityTest extends BaseRemoteTest
             String copyArgs[] = {"-copy", "benchmark::integer::20kb benchmark::integer::20kb-copy",
                                 "-url", this.connString, "-dest_url", this.connString,
                                 "-dest_cluster", this.thorClusterFileGroup,
-                                "-user", this.hpccUser, "-pass", this.hpccPass };
+                                "-user", this.hpccUser, "-pass", this.hpccPass, "-non_interactive" };
 
             JSONArray results = FileUtility.run(copyArgs);
             JSONObject result = results.optJSONObject(0);
@@ -87,7 +87,7 @@ public class FileUtilityTest extends BaseRemoteTest
             String writeArgs[] = {"-write", localDir + "benchmark__integer__20kb* benchmark::integer::20kb_write",
                                 "-url", this.connString, "-dest_url", this.connString,
                                 "-dest_cluster", this.thorClusterFileGroup,
-                                "-user", this.hpccUser, "-pass", this.hpccPass };
+                                "-user", this.hpccUser, "-pass", this.hpccPass, "-non_interactive" };
 
             JSONArray results = FileUtility.run(writeArgs);
             JSONObject result = results.optJSONObject(0);


### PR DESCRIPTION
- Added a non-interactive flag to FileUtility
- Updated FileUtilityTest to use the non-interactive flag

Signed-off-by: James McMullan James.McMullan@lexisnexis.com

<!-- Thank you for submitting a pull request to the hpcc4j project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues (https://track.hpccsystems.com/).
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 hpcc4j-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,and
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and check-off all the items that apply (after pull request has been created)
-->

## Type of change:
- [X] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).

## Checklist:
- [X] I have created a corresponding JIRA ticket for this submission
- [X] My code follows the code style of this project.
  - [ ] I have applied the Eclipse code-format template provided.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [X] I have read the HPCC Systems CONTRIBUTORS document (https://github.com/hpcc-systems/HPCC-Platform/wiki/Guide-for-contributors).
- [X] The change has been fully tested:
  - [ ] This change does not cause any existing JUnits to fail.
  - [ ] I have include JUnit coverage to test this change
  - [ ] I have performed system test and covered possible regressions and side effects.
- [X] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] This change fixes the problem, not just the symptom

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
