### PR TITLE
HPCC4J-691 DFSClient: Column pruner should clone field defs

### DIFF
--- a/dfsclient/src/main/java/org/hpccsystems/dfs/client/ColumnPruner.java
+++ b/dfsclient/src/main/java/org/hpccsystems/dfs/client/ColumnPruner.java
@@ -173,7 +173,7 @@ public class ColumnPruner implements Serializable
 
         if (fieldInfo.shouldCullChildren == false)
         {
-            return originalRecordDef;
+            return new FieldDef(originalRecordDef);
         }
 
         // Datasets are a special case. They will not have a component

--- a/dfsclient/src/test/java/org/hpccsystems/dfs/client/DFSHPCCFile.java
+++ b/dfsclient/src/test/java/org/hpccsystems/dfs/client/DFSHPCCFile.java
@@ -192,6 +192,43 @@ public class DFSHPCCFile extends BaseRemoteTest
         Assert.assertEquals(3, projectedRecordDefinition.getNumDefs());
     }
 
+    private boolean fieldDefinitionsAreSeparate(FieldDef fieldDef1, FieldDef fieldDef2)
+    {
+        for (int i = 0; i < fieldDef1.getNumDefs(); i++)
+        {
+            if (fieldDef1.getDef(i) == fieldDef2.getDef(i))
+            {
+                return false;
+            }
+
+            if (!fieldDefinitionsAreSeparate(fieldDef1.getDef(i), fieldDef2.getDef(i)))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    @Test
+    public final void testProjectedRecordDefCloning() throws Exception 
+    {
+        FieldDef recordDef = mockHPCCFile.getRecordDefinition();
+
+        String[] fieldNames = new String[recordDef.getNumDefs()];
+        for (int i = 0; i < recordDef.getNumDefs(); i++)
+        {
+            fieldNames[i] = recordDef.getDef(i).getFieldName();
+        }
+
+        String projectList = String.join(",", fieldNames);
+        mockHPCCFile.setProjectList(projectList);
+        FieldDef projectedRecordDefinition = mockHPCCFile.getProjectedRecordDefinition();
+
+        // Ensure the projected record definition is a clone and not modifying the original record definition
+        assert(fieldDefinitionsAreSeparate(recordDef, projectedRecordDefinition));
+    }
+
     @Test
     public final void testIsIndex()
     {


### PR DESCRIPTION
- Updated ColumnPruner to correctly clone child field defs

Signed-off-by: James McMullan James.McMullan@lexisnexis.com

<!-- Thank you for submitting a pull request to the hpcc4j project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues (https://track.hpccsystems.com/).
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 hpcc4j-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,and
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and check-off all the items that apply (after pull request has been created)
-->

## Type of change:
- [X] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).

## Checklist:
- [X] I have created a corresponding JIRA ticket for this submission
- [X] My code follows the code style of this project.
  - [ ] I have applied the Eclipse code-format template provided.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [X] I have read the HPCC Systems CONTRIBUTORS document (https://github.com/hpcc-systems/HPCC-Platform/wiki/Guide-for-contributors).
- [X] The change has been fully tested:
  - [ ] This change does not cause any existing JUnits to fail.
  - [ ] I have include JUnit coverage to test this change
  - [ ] I have performed system test and covered possible regressions and side effects.
- [X] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] This change fixes the problem, not just the symptom

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
