### PR TITLE
HPCC4J-696 DFSClient expose read buffer size setting

### DIFF
--- a/dfsclient/src/main/java/org/hpccsystems/dfs/client/HpccRemoteFileReader.java
+++ b/dfsclient/src/main/java/org/hpccsystems/dfs/client/HpccRemoteFileReader.java
@@ -72,6 +72,7 @@ public class HpccRemoteFileReader<T> implements Iterator<T>
         public boolean createPrefetchThread = true;
         public int initialReadSizeKB = -1;
         public int readSizeKB = -1;
+        public int readBufferSizeKB = -1;
         public int readRequestSpanBatchSize = -1; // The number of read requests before creating a new span
         public Span parentSpan = null;
     };
@@ -101,6 +102,7 @@ public class HpccRemoteFileReader<T> implements Iterator<T>
         context.connectTimeoutMS = readContext.connectTimeout;
         context.socketOpTimeoutMS = readContext.socketOpTimeoutMS;
         context.createPrefetchThread = readContext.createPrefetchThread;
+        context.readBufferSizeKB = readContext.readBufferSizeKB;
 
         return context;
     }

--- a/dfsclient/src/main/java/org/hpccsystems/dfs/client/RowServiceInputStream.java
+++ b/dfsclient/src/main/java/org/hpccsystems/dfs/client/RowServiceInputStream.java
@@ -452,14 +452,19 @@ public class RowServiceInputStream extends InputStream implements IProfilable
             this.initialReadSizeKB = context.initialReadSizeKB;
         }
 
-        // It doesn't make sense to increase the read buffer size beyond the max read size
-        int readBufferSize = context.readBufferSizeKB * 1024;
-        if (context.readBufferSizeKB > context.maxReadSizeKB)
+        int readBufferSizeKB = DEFAULT_READ_BUFFER_SIZE_KB;
+        if (context.readBufferSizeKB > 0)
         {
-            readBufferSize = context.maxReadSizeKB * 1024;
+            readBufferSizeKB = context.readBufferSizeKB;
         }
 
-        this.readBuffer = new CircularByteBuffer(readBufferSize);
+        // It doesn't make sense to increase the read buffer size beyond the max read size
+        if (readBufferSizeKB > this.maxReadSizeKB)
+        {
+            readBufferSizeKB = this.maxReadSizeKB;
+        }
+
+        this.readBuffer = new CircularByteBuffer(readBufferSizeKB * 1024);
 
         this.jsonRecordDefinition = RecordDefinitionTranslator.toJsonRecord(this.recordDefinition).toString();
         this.projectedJsonRecordDefinition = RecordDefinitionTranslator.toJsonRecord(this.projectedRecordDefinition).toString();


### PR DESCRIPTION
- Added missing read buffer size option in the read context
- Added missing check to make sure readBufferSize > 0

Signed-off-by: James McMullan James.McMullan@lexisnexis.com

<!-- Thank you for submitting a pull request to the hpcc4j project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues (https://track.hpccsystems.com/).
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 hpcc4j-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,and
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and check-off all the items that apply (after pull request has been created)
-->

## Type of change:
- [X] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).

## Checklist:
- [X] I have created a corresponding JIRA ticket for this submission
- [X] My code follows the code style of this project.
  - [ ] I have applied the Eclipse code-format template provided.
- [X] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [X] I have read the HPCC Systems CONTRIBUTORS document (https://github.com/hpcc-systems/HPCC-Platform/wiki/Guide-for-contributors).
- [X] The change has been fully tested:
  - [ ] This change does not cause any existing JUnits to fail.
  - [ ] I have include JUnit coverage to test this change
  - [ ] I have performed system test and covered possible regressions and side effects.
- [X] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] This change fixes the problem, not just the symptom

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
