### PR TITLE
HPCC4J-687 DFSClient read resume test failure

### DIFF
--- a/dfsclient/src/main/java/org/hpccsystems/dfs/client/HpccRemoteFileReader.java
+++ b/dfsclient/src/main/java/org/hpccsystems/dfs/client/HpccRemoteFileReader.java
@@ -317,7 +317,11 @@ public class HpccRemoteFileReader<T> implements Iterator<T>
                 this.readSpan.end();
                 throw e;
             }
-            this.inputStream.skip(bytesToSkip);
+
+            do
+            {
+                bytesToSkip -= this.inputStream.skip(bytesToSkip);
+            } while (bytesToSkip > 0);
 
             this.binaryRecordReader = new BinaryRecordReader(this.inputStream, resumeInfo.recordReaderStreamPos);
             this.binaryRecordReader.initialize(this.recordBuilder);
@@ -392,7 +396,11 @@ public class HpccRemoteFileReader<T> implements Iterator<T>
                 {
                     throw new Exception("Unable to restart read stream, unexpected stream position in record reader.");
                 }
-                this.inputStream.skip(bytesToSkip);
+
+                do
+                {
+                    bytesToSkip -= this.inputStream.skip(bytesToSkip);
+                } while (bytesToSkip > 0);
 
                 this.binaryRecordReader = new BinaryRecordReader(this.inputStream, resumeInfo.recordReaderStreamPos);
                 this.binaryRecordReader.initialize(this.recordBuilder);

--- a/dfsclient/src/main/java/org/hpccsystems/dfs/client/RowServiceInputStream.java
+++ b/dfsclient/src/main/java/org/hpccsystems/dfs/client/RowServiceInputStream.java
@@ -88,6 +88,9 @@ public class RowServiceInputStream extends InputStream implements IProfilable
     private static final int         LONG_WAIT_THRESHOLD_US   = 100;
     private static final int         MAX_HOT_LOOP_NS          = 10000;
 
+    // The number of fetch requests to keep in history, used for resuming reads
+    private static final int         FETCH_HISTORY_SIZE       = 10;
+
     // This is used to prevent the prefetch thread from hot looping when
     // the network connection is slow. The read on the socket will block until
     // at least 512 bytes are available
@@ -1224,6 +1227,12 @@ public class RowServiceInputStream extends InputStream implements IProfilable
             this.streamPosOfFetchStart += totalDataInCurrentRequest;
             synchronized (streamPosOfFetches)
             {
+                if (streamPosOfFetches.size() >= FETCH_HISTORY_SIZE)
+                {
+                    streamPosOfFetches.remove(0);
+                    tokenBinOfFetches.remove(0);
+                }
+
                 streamPosOfFetches.add(this.streamPosOfFetchStart);
                 tokenBinOfFetches.add(this.tokenBin);
             }


### PR DESCRIPTION
- Fixed issue where read resume could duplicate a record when restart occurs along a fetch boundary
- Added code to put a cap on the fetch history size

Signed-off-by: James McMullan James.McMullan@lexisnexis.com

<!-- Thank you for submitting a pull request to the hpcc4j project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues (https://track.hpccsystems.com/).
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 hpcc4j-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,and
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and check-off all the items that apply (after pull request has been created)
-->

## Type of change:
- [X] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).

## Checklist:
- [X] I have created a corresponding JIRA ticket for this submission
- [X] My code follows the code style of this project.
  - [ ] I have applied the Eclipse code-format template provided.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [X] I have read the HPCC Systems CONTRIBUTORS document (https://github.com/hpcc-systems/HPCC-Platform/wiki/Guide-for-contributors).
- [X] The change has been fully tested:
  - [ ] This change does not cause any existing JUnits to fail.
  - [ ] I have include JUnit coverage to test this change
  - [ ] I have performed system test and covered possible regressions and side effects.
- [X] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] This change fixes the problem, not just the symptom

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
