### PR TITLE
HPCC4J-724 Github Actions: Print pod logs on failure

### DIFF
--- a/.github/workflows/k8s-regression-suite.yml
+++ b/.github/workflows/k8s-regression-suite.yml
@@ -146,6 +146,14 @@ jobs:
     - name: Build with Maven
       run: mvn -B --activate-profiles jenkins-on-demand -Dmaven.gpg.skip=true -Dmaven.javadoc.skip=true -Dmaven.test.failure.ignore=true -Dhpccconn=https://eclwatch.default:8010 -Dwssqlconn=https://sql2ecl.default:8510 -DHPCC30117=open  install
 
+    - name: Print Rowservice Logs on Failure
+      if: hashFiles('./dfsclient/FailedTests.csv') != ''
+      run: |
+        echo "DFSClient tests failed - collecting rowservice pod logs"
+        ROWSERVICE_POD=$(kubectl get pods -l server=rowservice -o jsonpath='{.items[0].metadata.name}')
+        echo "Rowservice pod: $ROWSERVICE_POD"
+        kubectl logs $ROWSERVICE_POD | grep -v "meta info did not mark file"
+
     - name: Process Errors
       shell: python
       run: |

--- a/wsclient/src/test/java/org/hpccsystems/ws/client/TestResultNotifier.java
+++ b/wsclient/src/test/java/org/hpccsystems/ws/client/TestResultNotifier.java
@@ -24,10 +24,31 @@ import org.junit.runner.notification.RunListener;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.time.ZoneId;
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
 
 public class TestResultNotifier extends RunListener
 {
     PrintWriter failedTestsFile = null;
+    private DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yy/MM/dd HH:mm:ss")
+                                          .withZone(ZoneId.systemDefault());
+
+    public void testStarted(Description description) throws Exception
+    {
+        Instant instant = Instant.now();
+        String formattedTime = formatter.format(instant);
+        System.out.println("\n" + formattedTime +  " Starting: " + description.getClassName() + "." + description.getMethodName());
+        System.out.println("---------------------------------------------------------");
+    }
+
+    public void testFinished(Description description) throws Exception
+    {
+        Instant instant = Instant.now();
+        String formattedTime = formatter.format(instant);
+        System.out.println("\n" + formattedTime +  " Finished: " + description.getClassName() + "." + description.getMethodName());
+        System.out.println("---------------------------------------------------------");
+    }
 
     public void testFailure(Failure failure) throws Exception
     {


### PR DESCRIPTION
- Modified K8s regression suite to print pod logs on failure
- Changed test result notifier to log test start / end

Signed-off-by: James McMullan James.McMullan@lexisnexis.com

<!-- Thank you for submitting a pull request to the hpcc4j project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues (https://track.hpccsystems.com/).
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 hpcc4j-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,and
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and check-off all the items that apply (after pull request has been created)
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).

## Checklist:
- [X] I have created a corresponding JIRA ticket for this submission
- [X] My code follows the code style of this project.
  - [ ] I have applied the Eclipse code-format template provided.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [X] I have read the HPCC Systems CONTRIBUTORS document (https://github.com/hpcc-systems/HPCC-Platform/wiki/Guide-for-contributors).
- [X] The change has been fully tested:
  - [ ] This change does not cause any existing JUnits to fail.
  - [ ] I have include JUnit coverage to test this change
  - [ ] I have performed system test and covered possible regressions and side effects.
- [X] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] This change fixes the problem, not just the symptom

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
